### PR TITLE
chore: fix GOPATH and optimize post-create script

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,8 @@
           "editor.codeActionsOnSave": {
             "source.organizeImports": "explicit"
           }
-        }
+        },
+        "terminal.integrated.defaultProfile.linux": "zsh"
       }
     }
   },
@@ -41,6 +42,7 @@
   ],
 
   "remoteEnv": {
+    "GOPATH": "/home/vscode/go",
     "PATH": "/home/vscode/go/bin:${containerEnv:PATH}"
   },
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -11,7 +11,9 @@ echo '{"credsStore":""}' > "${HOME}/.docker/config.json"
 git config pull.rebase true
 
 # ── Go tools ────────────────────────────────────────────────────────────────
-echo "▶ Installing Go tools..."
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-
-echo "✓ Dev environment ready"
+if ! command -v golangci-lint &>/dev/null; then
+  echo "▶ Installing golangci-lint..."
+  go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+else
+  echo "✓ golangci-lint already installed: $(golangci-lint --version)"
+fi


### PR DESCRIPTION
## Summary
Fix GOPATH configuration and optimize the post-create script.

## Changes
- Set `GOPATH` to `/home/vscode/go` so Go tools persist in the home volume
- Skip `golangci-lint` install if already installed (faster rebuilds)
- Add zsh as default terminal profile in VS Code settings

Closes #2